### PR TITLE
Add php-7.3 test and other PHPUnit versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.7|^6.5"
+        "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Changed log
- Add `php-7.3` version test during Travis CI build.
- Add the `PHPUnit` `^7.0` and `^8.0` versions to be compatible with different PHP versions.